### PR TITLE
CI jobs parallelization to reduce autobahn test time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 on: [push, pull_request]
 
+# we dont run compression extension
+# in regular CI because it is a
+# time consuming operation.
+# we delegate it to manually triggered CI
+# and only run base autobahn tests here.
+
 jobs:
   build:
     strategy:
@@ -201,16 +207,54 @@ jobs:
           nimble install -y --depsOnly
           nimble test
 
+  autobahn-test:
+    if: github.event_name == 'push'
+    name: "Autobahn test suite"
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix:
+        websock: [ws, wsc, wss, wssc]
+
+    steps:
+      - name: Checkout nim-websock
+        uses: actions/checkout@v2
+        with:
+          path: nim-websock
+          submodules: true
+
+      - name: Get latest nimbus-build-system commit hash
+        id: versions
+        shell: bash
+        run: |
+          getHash() {
+            git ls-remote "https://github.com/$1" "${2:-HEAD}" | cut -f 1
+          }
+          nbsHash=$(getHash status-im/nimbus-build-system)
+          echo "::set-output name=nimbus_build_system::$nbsHash"
+
+      - name: Restore prebuilt Nim from cache
+        id: nim-cache
+        uses: actions/cache@v2
+        with:
+          path: NimBinaries
+          key: 'NimBinaries-${{ steps.versions.outputs.nimbus_build_system }}'
+
+      - name: Build Nim and associated tools
+        shell: bash
+        run: |
+          curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
+          env MAKE="make -j2" ARCH_OVERRIDE=x64 CC=gcc bash build_nim.sh nim csources dist/nimble NimBinaries
+          echo '${{ github.workspace }}/nim/bin' >> $GITHUB_PATH
+
       - name: Setup Python version
-        if: runner.os == 'linux' && matrix.target.cpu == 'amd64' && github.event_name == 'push'
         uses: actions/setup-python@v2
         with:
           python-version: pypy-2.7
 
-      - name: Setup and run Autobahn test suite.
-        # we switch to linux because
-        # kill $(pidof server) not working on macos
-        if: runner.os == 'linux' && matrix.target.cpu == 'amd64' && github.event_name == 'push'
+      - name: Setup Autobahn.
         run: |
           sudo apt-get install -y python-dev
           pip install virtualenv
@@ -219,50 +263,82 @@ jobs:
           source autobahn/bin/activate
           pip install autobahntestsuite
           cd nim-websock
+          nimble install -y --depsOnly
+
+      - name: Generate index.html
+        if: matrix.websock == 'ws'
+        run: |
+          cd nim-websock
           mkdir autobahn/reports
           sed -i "s/COMMIT_SHA_SHORT/${GITHUB_SHA::7}/g" autobahn/index.md
           sed -i "s/COMMIT_SHA/$GITHUB_SHA/g" autobahn/index.md
           markdown2 autobahn/index.md > autobahn/reports/index.html
 
-          nim c -d:release examples/server.nim
-          examples/server &
-          server1=$!
+      - name: Run Autobahn test suite.
+        run: |
+          source autobahn/bin/activate
+          case '${{ matrix.websock }}' in
+            ws)
+              cd nim-websock
+              nim c -d:release examples/server.nim
+              examples/server &
+              server=$!
 
-          nim c -d:tls -d:release -o:examples/tls_server examples/server.nim
-          examples/tls_server &
-          server2=$!
+              cd autobahn
+              wstest --mode fuzzingclient --spec fuzzingclient.json
+            ;;
+            wsc)
+              cd nim-websock
+              nim c -d:tls -d:release -o:examples/tls_server examples/server.nim
+              examples/tls_server &
+              server=$!
 
-          cd autobahn
-          wstest --webport=0 --mode fuzzingserver --spec fuzzingserver.json &
-          server3=$!
+              cd autobahn
+              wstest --mode fuzzingclient --spec fuzzingclient_tls.json
+            ;;
+            wss)
+              cd nim-websock/autobahn
+              wstest --webport=0 --mode fuzzingserver --spec fuzzingserver.json &
+              server=$!
 
-          wstest --webport=0 --mode fuzzingserver --spec fuzzingserver_tls.json &
-          server4=$!
+              cd ..
+              nim c -d:release examples/autobahn_client
+              examples/autobahn_client
+            ;;
+            wssc)
+              cd nim-websock/autobahn
+              wstest --webport=0 --mode fuzzingserver --spec fuzzingserver_tls.json &
+              server=$!
 
-          wstest --mode fuzzingclient --spec fuzzingclient.json &
-          client1=$!
+              cd ..
+              nim c -d:tls -d:release -o:examples/autobahn_tlsclient examples/autobahn_client
+              examples/autobahn_tlsclient
+            ;;
+          esac
 
-          wstest --mode fuzzingclient --spec fuzzingclient_tls.json &
-          client2=$!
+          kill $server
 
-          cd ..
-          nim c -d:release examples/autobahn_client
-          examples/autobahn_client &
-          client3=$!
+      - name: Upload Autobahn result
+        uses: actions/upload-artifact@v2
+        with:
+          name: autobahn-report
+          path: ./nim-websock/autobahn/reports
 
-          nim c -d:tls -d:release -o:examples/autobahn_tlsclient examples/autobahn_client
-          examples/autobahn_tlsclient &
-          client4=$!
+  deploy-test:
+    if: github.event_name == 'push'
+    name: "Deplay Autobahn results"
+    needs: autobahn-test
+    runs-on: ubuntu-latest
+    steps:
 
-          wait $client1 $client2 $client3 $client4
-          kill $server1
-          kill $server2
-          kill $server3
-          kill $server4
+      - name: Download Autobahn reports
+        uses: actions/download-artifact@v2
+        with:
+          name: autobahn-report
+          path: ./autobahn_reports
 
       - name: Deploy autobahn report.
-        if: runner.os == 'linux' && matrix.target.cpu == 'amd64' && github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./nim-websock/autobahn/reports
+          publish_dir: ./autobahn_reports


### PR DESCRIPTION
with the inclusion of compression extension,
the autobahn test suite took significant time
to pass. move it to manually triggered CI
as it cannot make the main CI to fail anyway.

we only run basic autobahn tests in regular CI.