### PR TITLE
make distinction between message and data APIs

### DIFF
--- a/examples/autobahn_client.nim
+++ b/examples/autobahn_client.nim
@@ -80,16 +80,15 @@ proc main() {.async.} =
 
       while ws.readystate != ReadyState.Closed:
         # echo back
-        let data = await ws.recvMsg()
-        let opCode = if ws.binary:
-                       Opcode.Binary
-                     else:
-                       Opcode.Text
+        if ws.binary:
+          let data = await ws.recvBinaryMsg()
+          await ws.sendBinaryMsg(data)
+        else:
+          let data = await ws.recvTextMsg()
+          await ws.sendTextMsg(data)
 
         if ws.readyState == ReadyState.Closed:
           break
-
-        await ws.send(data, opCode)
 
     except WebSocketError as exc:
       error "WebSocket error", exception = exc.msg

--- a/examples/autobahn_client.nim
+++ b/examples/autobahn_client.nim
@@ -43,7 +43,7 @@ proc getCaseCount(): Future[int] {.async.} =
   block:
     try:
       let ws = await connectServer("/getCaseCount")
-      let buff = await ws.recv()
+      let buff = await ws.recvMsg()
       let dataStr = string.fromBytes(buff)
       caseCount = parseInt(dataStr)
       await ws.close()
@@ -60,7 +60,7 @@ proc generateReport() {.async.} =
     trace "request autobahn server to generate report"
     let ws = await connectServer("/updateReports?agent=" & agent)
     while true:
-      let buff = await ws.recv()
+      let buff = await ws.recvMsg()
       if buff.len <= 0:
         break
     await ws.close()
@@ -80,7 +80,7 @@ proc main() {.async.} =
 
       while ws.readystate != ReadyState.Closed:
         # echo back
-        let data = await ws.recv()
+        let data = await ws.recvMsg()
         let opCode = if ws.binary:
                        Opcode.Binary
                      else:

--- a/examples/server.nim
+++ b/examples/server.nim
@@ -28,7 +28,7 @@ proc handle(request: HttpRequest) {.async.} =
 
     trace "Websocket handshake completed"
     while ws.readyState != ReadyState.Closed:
-      let recvData = await ws.recv()
+      let recvData = await ws.recvMsg()
       trace "Client Response: ", size = recvData.len, binary = ws.binary
 
       if ws.readyState == ReadyState.Closed:

--- a/examples/server.nim
+++ b/examples/server.nim
@@ -28,16 +28,15 @@ proc handle(request: HttpRequest) {.async.} =
 
     trace "Websocket handshake completed"
     while ws.readyState != ReadyState.Closed:
-      let recvData = await ws.recvMsg()
-      trace "Client Response: ", size = recvData.len, binary = ws.binary
-
-      if ws.readyState == ReadyState.Closed:
-        # if session already terminated by peer,
-        # no need to send response
-        break
-
-      await ws.send(recvData,
-        if ws.binary: Opcode.Binary else: Opcode.Text)
+      # echo back
+      if ws.binary:
+        let data = await ws.recvBinaryMsg()
+        trace "Client Response: ", size = data.len, binary = ws.binary
+        await ws.sendBinaryMsg(data)
+      else:
+        let data = await ws.recvTextMsg()
+        trace "Client Response: ", size = data.len, binary = ws.binary
+        await ws.sendTextMsg(data)
 
   except WebSocketError as exc:
     error "WebSocket error:", exception = exc.msg

--- a/tests/extensions/testcompression.nim
+++ b/tests/extensions/testcompression.nim
@@ -35,7 +35,7 @@ suite "permessage deflate compression":
       let ws = await server.handleRequest(request)
 
       while ws.readyState != ReadyState.Closed:
-        let recvData = await ws.recv()
+        let recvData = await ws.recvMsg()
         if ws.readyState == ReadyState.Closed:
           break
         await ws.send(recvData,
@@ -58,7 +58,7 @@ suite "permessage deflate compression":
 
     var recvData: seq[byte]
     while recvData.len < textData.len:
-      let res = await client.recv()
+      let res = await client.recvMsg()
       recvData.add res
       if client.readyState == ReadyState.Closed:
         break
@@ -75,7 +75,7 @@ suite "permessage deflate compression":
       )
       let ws = await server.handleRequest(request)
       while ws.readyState != ReadyState.Closed:
-        let recvData = await ws.recv()
+        let recvData = await ws.recvMsg()
         if ws.readyState == ReadyState.Closed:
           break
         await ws.send(recvData,
@@ -98,7 +98,7 @@ suite "permessage deflate compression":
 
     var recvData: seq[byte]
     while recvData.len < binaryData.len:
-      let res = await client.recv()
+      let res = await client.recvMsg()
       recvData.add res
       if client.readyState == ReadyState.Closed:
         break

--- a/tests/extensions/testexts.nim
+++ b/tests/extensions/testexts.nim
@@ -30,7 +30,7 @@ suite "multiple extensions flow":
         factories = [hexFactory, base64Factory],
       )
       let ws = await server.handleRequest(request)
-      let recvData = await ws.recv()
+      let recvData = await ws.recvMsg()
       await ws.send(recvData,
         if ws.binary: Opcode.Binary else: Opcode.Text)
 
@@ -50,7 +50,7 @@ suite "multiple extensions flow":
     )
 
     await client.send(testData)
-    let res = await client.recv()
+    let res = await client.recvMsg()
     check testData.toBytes() == res
     await client.close()
 
@@ -62,7 +62,7 @@ suite "multiple extensions flow":
         factories = [hexFactory, base64Factory],
       )
       let ws = await server.handleRequest(request)
-      let recvData = await ws.recv()
+      let recvData = await ws.recvMsg()
       await ws.send(recvData,
         if ws.binary: Opcode.Binary else: Opcode.Text)
 
@@ -82,6 +82,6 @@ suite "multiple extensions flow":
     )
 
     await client.send(testData)
-    let res = await client.recv()
+    let res = await client.recvMsg()
     check testData.toBytes() == res
     await client.close()

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -37,7 +37,7 @@ proc rndBin*(size: int): seq[byte] =
 proc waitForClose*(ws: WSSession) {.async.} =
   try:
     while ws.readystate != ReadyState.Closed:
-      discard await ws.recv()
+      discard await ws.recvMsg()
   except CatchableError:
     trace "Closing websocket"
 

--- a/tests/testutf8.nim
+++ b/tests/testutf8.nim
@@ -74,7 +74,7 @@ suite "UTF-8 DFA validator":
 proc waitForClose(ws: WSSession) {.async.} =
   try:
     while ws.readystate != ReadyState.Closed:
-      discard await ws.recv()
+      discard await ws.recvTextMsg()
   except CatchableError:
     trace "Closing websocket"
 
@@ -96,9 +96,9 @@ suite "UTF-8 validator in action":
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
 
-      let res = await ws.recv()
+      let res = await ws.recvTextMsg()
       check:
-        string.fromBytes(res) == testData
+        res == testData
         ws.binary == false
 
       await waitForClose(ws)
@@ -135,11 +135,11 @@ suite "UTF-8 validator in action":
 
       let server = WSServer.new(protos = ["proto"], onClose = onClose)
       let ws = await server.handleRequest(request)
-      let res = await ws.recv()
+      let res = await ws.recvTextMsg()
       await waitForClose(ws)
 
       check:
-        string.fromBytes(res) == testData
+        res == testData
         ws.binary == false
 
       await waitForClose(ws)
@@ -182,7 +182,7 @@ suite "UTF-8 validator in action":
     )
 
     expect WSInvalidUTF8:
-      let data = await session.recv()
+      let data = await session.recvTextMsg()
 
   test "invalid UTF-8 sequence close code":
     let closeReason = "i want to close\xc0\xaf"
@@ -207,4 +207,4 @@ suite "UTF-8 validator in action":
     )
 
     expect WSInvalidUTF8:
-      let data = await session.recv()
+      let data = await session.recvTextMsg()

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -109,9 +109,9 @@ suite "Test transmission":
 
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let servRes = await ws.recv()
+      let servRes = await ws.recvTextMsg()
 
-      check string.fromBytes(servRes) == testString
+      check servRes == testString
       await ws.waitForClose()
 
     server = createServer(
@@ -129,8 +129,8 @@ suite "Test transmission":
       check request.uri.path == WSPath
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let servRes = await ws.recv()
-      check string.fromBytes(servRes) == testString
+      let servRes = await ws.recvTextMsg()
+      check servRes == testString
       await ws.waitForClose()
 
     server = createServer(
@@ -158,8 +158,8 @@ suite "Test transmission":
       flags = {ReuseAddr})
 
     let session = await connectClient()
-    var clientRes = await session.recv()
-    check string.fromBytes(clientRes) == testString
+    var clientRes = await session.recvTextMsg()
+    check clientRes == testString
     await waitForClose(session)
 
 suite "Test ping-pong":
@@ -265,7 +265,7 @@ suite "Test ping-pong":
       let ws = await server.handleRequest(request)
 
       expect WSPayloadTooLarge:
-        discard await ws.recv()
+        discard await ws.recvMsg()
 
       await waitForClose(ws)
 
@@ -334,7 +334,7 @@ suite "Test framing":
     let session = await connectClient()
 
     expect WSMaxMessageSizeError:
-      discard await session.recv(5)
+      discard await session.recvMsg(5)
     await waitForClose(session)
 
 suite "Test Closing":
@@ -575,11 +575,11 @@ suite "Test Payload":
 
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let servRes = await ws.recv()
+      let servRes = await ws.recvTextMsg()
 
       check:
         servRes.len == 0
-        string.fromBytes(servRes) == emptyStr
+        servRes == emptyStr
 
       await ws.send(emptyStr)
       await ws.waitForClose()
@@ -591,11 +591,11 @@ suite "Test Payload":
 
     let session = await connectClient()
     await session.send(emptyStr)
-    let clientRes = await session.recv()
+    let clientRes = await session.recvTextMsg()
 
     check:
       clientRes.len == 0
-      string.fromBytes(clientRes) == emptyStr
+      clientRes == emptyStr
 
     await session.close()
 
@@ -607,11 +607,11 @@ suite "Test Payload":
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
       for _ in 0..<3:
-        let servRes = await ws.recv()
+        let servRes = await ws.recvTextMsg()
 
         check:
           servRes.len == 0
-          string.fromBytes(servRes) == emptyStr
+          servRes == emptyStr
 
       for i in 0..3:
         await ws.send(emptyStr)
@@ -629,11 +629,11 @@ suite "Test Payload":
       await session.send(emptyStr)
 
     for _ in 0..<3:
-      let clientRes = await session.recv()
+      let clientRes = await session.recvTextMsg()
 
       check:
         clientRes.len == 0
-        string.fromBytes(clientRes) == emptyStr
+        clientRes == emptyStr
 
     await session.close()
 
@@ -648,10 +648,10 @@ suite "Test Payload":
       let server = WSServer.new(protos = ["proto"])
 
       let ws = await server.handleRequest(request)
-      let respData = await ws.recv()
+      let respData = await ws.recvTextMsg()
 
       check:
-        string.fromBytes(respData) == testString
+        respData == testString
 
       await waitForClose(ws)
 
@@ -706,9 +706,9 @@ suite "Test Payload":
         )
 
       let ws = await server.handleRequest(request)
-      let respData = await ws.recv()
+      let respData = await ws.recvTextMsg()
       check:
-        string.fromBytes(respData)   == testString
+        respData  == testString
 
       await waitForClose(ws)
 
@@ -764,7 +764,7 @@ suite "Test Payload":
 
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let res = await ws.recv()
+      let res = await ws.recvMsg()
 
       check ws.binary == false
       await ws.send(res, Opcode.Text)
@@ -781,11 +781,11 @@ suite "Test Payload":
     )
 
     await ws.send(testData)
-    let echoed = await ws.recv()
+    let echoed = await ws.recvTextMsg()
     await ws.close()
 
     check:
-      string.fromBytes(echoed) == testData
+      echoed == testData
       ws.binary == false
 
 suite "Test Binary message with Payload":
@@ -800,7 +800,7 @@ suite "Test Binary message with Payload":
 
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let servRes = await ws.recv()
+      let servRes = await ws.recvMsg()
 
       check:
         servRes == emptyData
@@ -825,7 +825,7 @@ suite "Test Binary message with Payload":
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
 
-      let servRes = await ws.recv()
+      let servRes = await ws.recvMsg()
 
       check:
         servRes == emptyData
@@ -858,7 +858,7 @@ suite "Test Binary message with Payload":
       )
       let ws = await server.handleRequest(request)
 
-      let res = await ws.recv()
+      let res = await ws.recvMsg()
       check:
         res == testData
         ws.binary == true
@@ -892,7 +892,7 @@ suite "Test Binary message with Payload":
       )
       let ws = await server.handleRequest(request)
 
-      let res = await ws.recv()
+      let res = await ws.recvMsg()
       check:
         res == testData
         ws.binary == true
@@ -921,7 +921,7 @@ suite "Test Binary message with Payload":
 
       let server = WSServer.new(protos = ["proto"])
       let ws = await server.handleRequest(request)
-      let res = await ws.recv()
+      let res = await ws.recvMsg()
 
       check:
         ws.binary == true
@@ -941,7 +941,7 @@ suite "Test Binary message with Payload":
     )
 
     await ws.send(testData, Opcode.Binary)
-    let echoed = await ws.recv()
+    let echoed = await ws.recvMsg()
 
     check:
       echoed == testData

--- a/websock.nimble
+++ b/websock.nimble
@@ -27,6 +27,8 @@ requires "https://github.com/status-im/nim-zlib"
 task test, "run tests":
   # dont't need to run it, only want to test if it is compileable
   exec "nim c -c --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:chronicles_sinks:json ./tests/testcommon"
+  exec "nim c -c --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:chronicles_sinks:json ./examples/autobahn_client.nim"
+  exec "nim c -c --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:chronicles_sinks:json ./examples/server.nim"
 
   exec "nim --hints:off c -r --opt:speed -d:debug --verbosity:0 --hints:off -d:chronicles_log_level=info ./tests/testcommon.nim"
   rmFile "./tests/testcommon"

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -445,8 +445,8 @@ proc recvTextMsg*(
 
 proc sendTextMsg*(
   ws: WSSession,
-  data: seq[byte]): Future[void] {.raises: [Defect, WSClosedError].} =
-  ws.send(data, Opcode.Text)
+  data: string): Future[void] {.raises: [Defect, WSClosedError].} =
+  ws.send(data)
 
 proc recvBinaryMsg*(
   ws: WSSession,


### PR DESCRIPTION
fix #85 

- rename `recv` to `recvMsg`
- add `recvTextMsg`/`sendTextMsg` and `recvBinaryMsg`/`sendBinaryMsg`
- move utf8 validation to `recvTextMsg`