### PR TITLE
Generalise low-level recv() for accepting partial frames

### DIFF
--- a/tests/extensions/testcompression.nim
+++ b/tests/extensions/testcompression.nim
@@ -12,6 +12,7 @@ import pkg/[chronos, stew/byteutils, stew/io2]
 import ../asyncunit
 import ../../websock/websock, ../helpers
 import ../../websock/extensions/compression/deflate
+import chronicles
 
 const
   dataFolder = "tests" / "extensions" / "data"

--- a/tests/extensions/testexts.nim
+++ b/tests/extensions/testexts.nim
@@ -7,14 +7,23 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/[chronos, stew/byteutils]
-import ../asyncunit
-import ./base64ext, ./hexext
-import ../../websock/websock, ../helpers
+import
+  pkg/[
+    asynctest,
+    chronos,
+    httputils,
+    stew/byteutils],
+  ../../websock/websock,
+  ../helpers,
+  ./base64ext,
+  ./hexext
+
+let
+  address = initTAddress("127.0.0.1:8888")
+var
+  server: HttpServer
 
 suite "multiple extensions flow":
-  var server: HttpServer
-  let address = initTAddress("127.0.0.1:8888")
   let hexFactory = hexFactory()
   let base64Factory = base64Factory(padding = true)
 
@@ -36,18 +45,14 @@ suite "multiple extensions flow":
 
       await waitForClose(ws)
 
-    server = HttpServer.create(
-      address,
-      handle,
+    server = createServer(
+      address = address,
+      handler = handle,
       flags = {ReuseAddr})
-    server.start()
 
-    let client = await WebSocket.connect(
-      host = "127.0.0.1:8888",
-      path = "/ws",
-      protocols = @["proto"],
-      factories = @[hexFactory, base64Factory]
-    )
+    let client = await connectClient(
+      address = address,
+      factories = @[hexFactory, base64Factory])
 
     await client.send(testData)
     let res = await client.recv()
@@ -68,18 +73,14 @@ suite "multiple extensions flow":
 
       await waitForClose(ws)
 
-    server = HttpServer.create(
-      address,
-      handle,
+    server = createServer(
+      address = address,
+      handler = handle,
       flags = {ReuseAddr})
-    server.start()
 
-    let client = await WebSocket.connect(
-      host = "127.0.0.1:8888",
-      path = "/ws",
-      protocols = @["proto"],
-      factories = @[base64Factory, hexFactory]
-    )
+    let client = await connectClient(
+      address = address,
+      factories = @[hexFactory, base64Factory])
 
     await client.send(testData)
     let res = await client.recv()

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -93,7 +93,8 @@ proc connectClient*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: Rng = nil): Future[WSSession] {.async.} =
+  rng: Rng = nil,
+  factories: seq[ExtFactory] = @[]): Future[WSSession] {.async.} =
   let secure = when defined secure: true else: false
   return await WebSocket.connect(
     host = address,
@@ -106,4 +107,5 @@ proc connectClient*(
     onPing = onPing,
     onPong = onPong,
     onClose = onClose,
-    rng = rng)
+    rng = rng,
+    factories = factories)

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -345,7 +345,8 @@ proc recv*(
   ## mode (aka utf8) but not the other way round. It allows to process the
   ## final read mode only when all of the frame sequence was read after the
   ## very last frame. The `text` mode is seen to be more restrictive than
-  ## `binary` mode.
+  ## `binary` mode. Note that RFC 6455 requires that all frames in a message
+  ## are of the same type.
   ##
   ## If the frame data types change from `text` to `binary`, a
   ## `WSOpcodeMismatchError` exception is thrown unless the `ws` descriptor

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -81,7 +81,6 @@ type
     readyState*: ReadyState
     masked*: bool # send masked packets
     binary*: bool # is payload binary?
-    textSwitchOk*: bool # allow switch from text => bin between frames
     flags*: set[TLSFlags]
     rng*: Rng
     frameSize*: int

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -81,6 +81,7 @@ type
     readyState*: ReadyState
     masked*: bool # send masked packets
     binary*: bool # is payload binary?
+    textSwitchOk*: bool # allow switch from text => bin between frames
     flags*: set[TLSFlags]
     rng*: Rng
     frameSize*: int
@@ -91,6 +92,7 @@ type
   WSSession* = ref object of WebSocket
     stream*: AsyncStream
     frame*: Frame
+    seen*: bool # true => at least one frame was seen
     proto*: string
 
   Ext* = ref object of RootObj

--- a/websock/utf8dfa.nim
+++ b/websock/utf8dfa.nim
@@ -8,11 +8,11 @@
 ## those terms.
 
 # DFA based UTF8 decoder/validator
-# See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+# See https://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
 
 const
-  UTF8_ACCEPT* = 0
-  UTF8_REJECT* = 1
+  UTF8_ACCEPT = 0
+  UTF8_REJECT = 1
 
 const utf8Table = [
   0'u8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, # 00..1f
@@ -31,9 +31,52 @@ const utf8Table = [
   1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, # s7..s8
 ]
 
+
+proc utf8Count*[T: byte|char](s: openArray[T]): (int,int) {.inline.} =
+  ## Count utf8 related entities of argument string `s`. The function returns
+  ## the integer pair
+  ## ::
+  ##   (<#code-points>,<#bytes-parsed>)
+  ##
+  ## where the first integer `<#code-points>` is the number of correctly parsed
+  ## leading code points. The second integer `<#bytes-parsed>` is the number of
+  ## bytes these code points have when `utf8` encoded.
+  ##
+  ## As a consequence, checking whether a given utf8 encoded `text` is correct
+  ## using this function would read
+  ## ::
+  ##   text.utf8Count[1] == text.len
+  ##
+  ## i.e. the size of leading code points is all of the `text`.
+  var
+    state = UTF8_ACCEPT
+    rdPos = 0
+
+  while rdPos < s.len:
+    let
+      charClass = utf8Table[s[rdPos].int].int
+      newState = utf8Table[256 + state*16 + charClass].int
+
+    # Character was processed
+    rdPos.inc
+
+    # Update result state not until the code point is complete
+    if newState == UTF8_ACCEPT:
+      result[0].inc
+      result[1] = rdPos
+    elif newState == UTF8_REJECT:
+      return
+
+    # Ready for next character
+    state = newState
+
+proc utf8Prequel*[T: byte|char](s: openArray[T]): int {.inline.} =
+  ## Shortcut for `s.utf8Count[1]` which is the maximum length of
+  ## leading utf8 characters as byte sequence.
+  s.utf8Count[1]
+
 proc validateUTF8*[T: byte | char](text: openArray[T]): bool =
-  var state = 0
-  for c in text:
-    let x = utf8Table[c.int].int
-    state = utf8Table[256 + state*16 + x].int
-  state == UTF8_ACCEPT
+  ## Return `true` if the argument `text` is a valid utf8 encoded text.
+  text.utf8Count[1] == text.len
+
+# End


### PR DESCRIPTION
Intended goal is to make it possible to to verify utf8 text in the WS package. The main showstopper is when frame boundaries are in the middle of utf8 code points. 

There are some more details to consider.
- The internal state machine might allow for frame mode changes beween binary and text (rfc6455 states that all frames have the same type.) This has been solved in a way that text mode is sticky. Switching _binary=>text_ is ok but _text=>binary_ throws an exception (unless confirmed by a descriptor flag.)

Todo:
- require text/binary mode to be all the same in a message once utf8 processing works OK
- add/update unit tests for utf8 scenarios OK

compare against #90, this draft is a study and should be ditched by @dryajov or others after checking usefulness