### PR TITLE
Remove version pin on chronicles

### DIFF
--- a/websock.nimble
+++ b/websock.nimble
@@ -17,7 +17,7 @@ skipDirs    = @["examples", "tests"]
 requires "nim >= 1.2.0" # nimble will fail to install nim-websock if we are using 1.2.6 here
 requires "chronos >= 3.0.0"
 requires "httputils >= 0.2.0"
-requires "chronicles"
+requires "chronicles >= 0.10.2"
 requires "stew >= 0.1.0"
 requires "asynctest >= 0.3.0 & < 0.4.0"
 requires "nimcrypto"

--- a/websock.nimble
+++ b/websock.nimble
@@ -17,7 +17,7 @@ skipDirs    = @["examples", "tests"]
 requires "nim >= 1.2.0" # nimble will fail to install nim-websock if we are using 1.2.6 here
 requires "chronos >= 3.0.0"
 requires "httputils >= 0.2.0"
-requires "chronicles#ba2817f1"
+requires "chronicles"
 requires "stew >= 0.1.0"
 requires "asynctest >= 0.3.0 & < 0.4.0"
 requires "nimcrypto"


### PR DESCRIPTION
Caused dependency conflicts when combining websock with other
packages that depend on chronicles, now that chronicles has
a new version (0.10.2).