### PR TITLE
Accept timeout

### DIFF
--- a/websock/http/common.nim
+++ b/websock/http/common.nim
@@ -67,6 +67,11 @@ proc closeWait*(stream: AsyncStream) {.async.} =
     stream.writer.closeStream(),
     stream.reader.tsource.closeTransp())
 
+proc close*(stream: AsyncStream) =
+  stream.reader.close()
+  stream.writer.close()
+  stream.reader.tsource.close()
+
 proc sendResponse*(
   request: HttpRequest,
   code: HttpCode,

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -200,7 +200,7 @@ proc accept*(server: HttpServer): Future[HttpRequest]
     raise newException(HttpError, "Timed out parsing request")
   except CatchableError as exc:
     # Can't hold up the accept loop
-    asyncSpawn stream.closeWait()
+    stream.close()
     raise exc
 
 

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -221,7 +221,8 @@ proc create*(
     headersTimeout: headersTimeout,
     handshakeTimeout:
       if handshakeTimeout == 0.seconds:
-        headersTimeout + headersTimeout div 20
+        # default to headersTimeout * 1.05
+        headersTimeout + (headersTimeout div 20)
       else: handshakeTimeout,
   )
 

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -262,7 +262,8 @@ proc create*(
     headersTimeout: headersTimeout,
     handshakeTimeout:
       if handshakeTimeout == 0.seconds:
-        headersTimeout + headersTimeout div 20
+        # default to headersTimeout * 1.05
+        headersTimeout + (headersTimeout div 20)
       else: handshakeTimeout,
     secure: true,
     handler: handler,

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -206,12 +206,13 @@ proc create*(
   _: typedesc[HttpServer],
   address: TransportAddress,
   handler: HttpAsyncCallback = nil,
-  flags: set[ServerFlags] = {}): HttpServer
+  flags: set[ServerFlags] = {},
+  handshakeTimeout = HttpHeadersTimeout): HttpServer
   {.raises: [Defect, CatchableError].} = # TODO: remove CatchableError
   ## Make a new HTTP Server
   ##
 
-  var server = HttpServer(handler: handler)
+  var server = HttpServer(handler: handler, handshakeTimeout: handshakeTimeout)
   server = HttpServer(
     createStreamServer(
       address,
@@ -233,7 +234,7 @@ proc create*(
   ## Make a new HTTP Server
   ##
 
-  return HttpServer.create(initTAddress(host), handler, flags)
+  return HttpServer.create(initTAddress(host), handler, flags, handshakeTimeout)
 
 proc create*(
   _: typedesc[TlsHttpServer],


### PR DESCRIPTION
Closes #79 

Ended up doing something very similar to #95, because each step of the parseRequest (including it's error handling) can go stale