### PR TITLE
Fix: handle simultaneous closing properly

### DIFF
--- a/websock/session.nim
+++ b/websock/session.nim
@@ -454,7 +454,11 @@ proc close*(
       opcode = Opcode.Close)
 
     # read frames until closed
-    while ws.readyState != ReadyState.Closed:
-      discard await ws.readFrame()
+    try:
+      while ws.readyState != ReadyState.Closed:
+        discard await ws.readFrame()
+    except CatchableError as exc:
+      ws.readyState = ReadyState.Closed
+      await ws.stream.closeWait()
   except CatchableError as exc:
     trace "Exception closing", exc = exc.msg


### PR DESCRIPTION
Since we use readFrame instead of readMsg, we need to handle
it's possible exceptions. Closes #111