### PR TITLE
properly support concurrent message sending

### DIFF
--- a/tests/extensions/testcompression.nim
+++ b/tests/extensions/testcompression.nim
@@ -7,13 +7,13 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import std/os
+import std/[os, strutils]
 import pkg/[chronos/unittest2/asynctests, stew/io2]
 import ../../websock/websock
 import ../../websock/extensions/compression/deflate
 
 const
-  dataFolder = "tests" / "extensions" / "data"
+  dataFolder = currentSourcePath.rsplit(os.DirSep, 1)[0] / "data"
 
 suite "permessage deflate compression":
   setup:

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -409,6 +409,9 @@ suite "Test framing":
         except CatchableError:
           fail()
 
+      expect WSClosedError:
+        discard await ws.recvMsg()  # try to receive canceled message
+
       await waitForClose(ws)
 
     server = createServer(
@@ -424,7 +427,7 @@ suite "Test framing":
     for i in 0 ..< numMessages:
       futs.add session.send(testData, Opcode.Binary)
     futs[0].cancel()  # expected to complete as it already started sending
-    futs[^1].cancel() # expected to be canceled as it has not started yet
+    futs[^2].cancel()  # expected to be canceled as it has not started yet
     await allFutures(futs)
     await session.close()
 

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -7,7 +7,10 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import std/strutils
+import std/[
+  random,
+  sequtils,
+  strutils]
 import pkg/[
   httputils,
   chronos/unittest2/asynctests,
@@ -351,6 +354,117 @@ suite "Test framing":
     expect WSMaxMessageSizeError:
       discard await session.recvMsg(5)
     await waitForClose(session)
+
+  asyncTest "should serialize long messages":
+    const numMessages = 10
+    let testData = newSeqWith(10 * 1024 * 1024, byte.rand())
+
+    proc handle(request: HttpRequest) {.async.} =
+      check request.uri.path == WSPath
+
+      let server = WSServer.new(protos = ["proto"])
+      let ws = await server.handleRequest(request)
+
+      for i in 0 ..< numMessages:
+        try:
+          let message = await ws.recvMsg()
+          let matchesExpectedMessage = (message == testData)
+          check matchesExpectedMessage
+        except CatchableError:
+          fail()
+
+      await waitForClose(ws)
+
+    server = createServer(
+      address = address,
+      handler = handle,
+      flags = {ReuseAddr})
+
+    let session = await connectClient(
+      address = initTAddress("127.0.0.1:8888"),
+      frameSize = 1 * 1024 * 1024)
+
+    var futs: seq[Future[void]]
+    for i in 0 ..< numMessages:
+      futs.add session.send(testData, Opcode.Binary)
+    await allFutures(futs)
+    await session.close()
+
+  asyncTest "should handle cancellations":
+    const numMessages = 10
+    let expectedNumMessages = numMessages - 1
+    let testData = newSeqWith(10 * 1024 * 1024, byte.rand())
+
+    proc handle(request: HttpRequest) {.async.} =
+      check request.uri.path == WSPath
+
+      let server = WSServer.new(protos = ["proto"])
+      let ws = await server.handleRequest(request)
+
+      for i in 0 ..< expectedNumMessages:
+        try:
+          let message = await ws.recvMsg()
+          let matchesExpectedMessage = (message == testData)
+          check matchesExpectedMessage
+        except CatchableError:
+          fail()
+
+      await waitForClose(ws)
+
+    server = createServer(
+      address = address,
+      handler = handle,
+      flags = {ReuseAddr})
+
+    let session = await connectClient(
+      address = initTAddress("127.0.0.1:8888"),
+      frameSize = 1 * 1024 * 1024)
+
+    var futs: seq[Future[void]]
+    for i in 0 ..< numMessages:
+      futs.add session.send(testData, Opcode.Binary)
+    futs[0].cancel()  # expected to complete as it already started sending
+    futs[^1].cancel() # expected to be canceled as it has not started yet
+    await allFutures(futs)
+    await session.close()
+
+  asyncTest "should prioritize control packets":
+    const numMessages = 10
+    let testData = newSeqWith(10 * 1024 * 1024, byte.rand())
+
+    proc handle(request: HttpRequest) {.async.} =
+      check request.uri.path == WSPath
+
+      let server = WSServer.new(protos = ["proto"])
+      let ws = await server.handleRequest(request)
+
+      expect WSClosedError:
+        discard await ws.recvMsg()
+
+      await waitForClose(ws)
+
+    server = createServer(
+      address = address,
+      handler = handle,
+      flags = {ReuseAddr})
+
+    let session = await connectClient(
+      address = initTAddress("127.0.0.1:8888"),
+      frameSize = 1 * 1024 * 1024)
+
+    let messageFut = session.send(testData, Opcode.Binary)
+
+    # interleave ping packets
+    var futs: seq[Future[void]]
+    for i in 0 ..< numMessages:
+      futs.add session.send(opcode = Opcode.Ping)
+    await allFutures(futs)
+    check not messageFut.finished
+
+    # interleave close packet
+    await session.close()
+    check messageFut.finished
+    await messageFut
 
 suite "Test Closing":
   setup:

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -146,6 +146,8 @@ proc doSend(
 proc sendLoop(ws: WSSession) {.gcsafe, async.} =
   while ws.sendQueue.len > 0:
     let task = ws.sendQueue.popFirst()
+    if task.fut.cancelled:
+      continue
 
     try:
       await ws.doSend(task.data, task.opcode)

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -151,7 +151,7 @@ proc doSend(
 
   sendFut
 
-proc continueSending(ws: WSSession) =
+proc continueSending(ws: WSSession) {.gcsafe.} =
   while ws.sendQueue.len > 0:
     let
       task = ws.sendQueue.popFirst()

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -106,7 +106,7 @@ type
     # fragments of another message unless an extension has been
     # negotiated that can interpret the interleaving.
     # See RFC 6455 Section 5.4 Fragmentation
-    sendFut*: Future[void]
+    sendLoop*: Future[void]
     sendQueue*: Deque[
       tuple[data: seq[byte], opcode: Opcode, fut: Future[void]]]
 


### PR DESCRIPTION
`nim-websock` suffered from a number of issues that are being addressed:

1. Long messages > `frameSize` (default 1 MB) were split into fragments
   of `frameSize` each. However, when a concurrent message is sent, it
   may be interleaved among the fragments of an already-sending message.
   This is only allowed for control packets without a mux extension.

2. When the WebSocket session is closed, a msg may have been partially
   received. This partial frame was reported as a full message, without
   indication that the receiving was canceled. This behaviour is fixed
   by raising a `WSClosedError` instead of reporting the partial msg.

3. When an individual `send` operation was canceled, it would actually
   stop sending the remainder of a potentially partially sent messages.
   This would corrupt the stream for concurrent and followup operations.
   Cancellation is now inhibited for the message currently sending.
   It is still possible to cancel messages that are not yet scheduled.

4. Messages could get reordered when using asynchronous encoders. This
   is addressed by delaying followup messages until the current message
   is fully encoded and transmitted (except for control packets).