### PR TITLE
configure SNI hostname when connecting WSS

### DIFF
--- a/websock/websock.nim
+++ b/websock/websock.nim
@@ -236,6 +236,7 @@ proc connect*(
   return WebSocket.connect(
     host = uri.hostname & ":" & uri.port,
     path = uri.path,
+    hostName = uri.hostname,
     protocols = protocols,
     factories = factories,
     hooks = hooks,


### PR DESCRIPTION
When connecting to WebSocket via TLS, certain servers require hostname to be sent as part of SNI extension. This was done when using `news` backend, but not when using `nim-websock` backend. Aligned both impls.