### PR TITLE
Fix closing leak

### DIFF
--- a/websock/session.nim
+++ b/websock/session.nim
@@ -249,7 +249,7 @@ proc handleClose*(
   if ws.readyState != ReadyState.Closing:
     ws.readyState = ReadyState.Closing
     trace "Sending close", code = ord(code), reason
-    await ws.send(prepareCloseBody(code, reason), Opcode.Close)
+    discard await ws.send(prepareCloseBody(code, reason), Opcode.Close).withTimeout(5.seconds)
 
     ws.readyState = ReadyState.Closed
 

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -249,7 +249,10 @@ proc handleClose*(
   if ws.readyState != ReadyState.Closing:
     ws.readyState = ReadyState.Closing
     trace "Sending close", code = ord(code), reason
-    discard await ws.send(prepareCloseBody(code, reason), Opcode.Close).withTimeout(5.seconds)
+    try:
+      await ws.send(prepareCloseBody(code, reason), Opcode.Close).wait(5.seconds)
+    except CatchableError as exc:
+      debug "Failed to send Close opcode", err=exc.msg
 
     ws.readyState = ReadyState.Closed
 

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -252,7 +252,7 @@ proc handleClose*(
     try:
       await ws.send(prepareCloseBody(code, reason), Opcode.Close).wait(5.seconds)
     except CatchableError as exc:
-      debug "Failed to send Close opcode", err=exc.msg
+      trace "Failed to send Close opcode", err=exc.msg
 
     ws.readyState = ReadyState.Closed
 


### PR DESCRIPTION
see: https://github.com/status-im/nwaku/issues/1186

A peer can make us wait forever when closing a connection.
This PR instead tries to be nice and wait for him, but kills the connection after a while