### PR TITLE
align RNG use with `nim-eth`

### DIFF
--- a/tests/extensions/testextflow.nim
+++ b/tests/extensions/testextflow.nim
@@ -121,7 +121,7 @@ suite "Decode frame extensions flow":
   var
     address: TransportAddress
     server: StreamServer
-    maskKey = genMaskKey(HmacDrbgContext.new())
+    maskKey = genMaskKey(SecureRngContext.new())
     transport: StreamTransport
     reader: AsyncStreamReader
     frame: Frame

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -79,16 +79,18 @@ proc createServer*(
     raise newException(Defect, exc.msg)
 
 proc connectClient*(
-  address = initTAddress("127.0.0.1:8888"),
-  path = WSPath,
-  protocols: seq[string] = @["proto"],
-  flags: set[TLSFlags] = {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
-  version = WSDefaultVersion,
-  frameSize = WSDefaultFrameSize,
-  onPing: ControlCb = nil,
-  onPong: ControlCb = nil,
-  onClose: CloseCb = nil,
-  rng: ref SecureRngContext = nil): Future[WSSession] {.async.} =
+    address = initTAddress("127.0.0.1:8888"),
+    path = WSPath,
+    protocols: seq[string] = @["proto"],
+    flags: set[TLSFlags] = {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
+    version = WSDefaultVersion,
+    frameSize = WSDefaultFrameSize,
+    onPing: ControlCb = nil,
+    onPong: ControlCb = nil,
+    onClose: CloseCb = nil,
+    rng = SecureRngContext.new()): Future[WSSession] {.async.} =
+  doAssert rng != nil, "Cannot initialize RNG"
+
   let secure = when defined secure: true else: false
   return await WebSocket.connect(
     host = address,

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -88,7 +88,7 @@ proc connectClient*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: Rng = nil): Future[WSSession] {.async.} =
+  rng: ref SecureRngContext = nil): Future[WSSession] {.async.} =
   let secure = when defined secure: true else: false
   return await WebSocket.connect(
     host = address,

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -806,7 +806,7 @@ suite "Test Payload":
       address = initTAddress("127.0.0.1:8888"),
       frameSize = maxFrameSize)
 
-    let maskKey = genMaskKey(HmacDrbgContext.new())
+    let maskKey = genMaskKey(SecureRngContext.new())
     await session.stream.writer.write(
       (await Frame(
         fin: false,
@@ -866,7 +866,7 @@ suite "Test Payload":
         pong = true
     )
 
-    let maskKey = genMaskKey(HmacDrbgContext.new())
+    let maskKey = genMaskKey(SecureRngContext.new())
     await session.stream.writer.write(
       (await Frame(
         fin: false,

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -89,7 +89,7 @@ type
     masked*: bool             # send masked packets
     binary*: bool             # is payload binary?
     flags*: set[TLSFlags]
-    rng*: Rng
+    rng*: ref SecureRngContext
     frameSize*: int           # max frame buffer size
     onPing*: ControlCb
     onPong*: ControlCb

--- a/websock/utils.nim
+++ b/websock/utils.nim
@@ -13,6 +13,8 @@ import bearssl/rand
 
 type SecureRngContext* = HmacDrbgContext
 
+export rand.generate
+
 ## Random helpers: similar as in stdlib, but with SecureRngContext rng
 # TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64

--- a/websock/utils.nim
+++ b/websock/utils.nim
@@ -1,5 +1,5 @@
 ## nim-websock
-## Copyright (c) 2021 Status Research & Development GmbH
+## Copyright (c) 2021-2023 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,30 +7,33 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import bearssl/[rand]
-export rand
+{.push raises: [].}
 
-## Random helpers: similar as in stdlib, but with HmacDrbgContext rng
+import bearssl/rand
+
+type SecureRngContext* = HmacDrbgContext
+
+## Random helpers: similar as in stdlib, but with SecureRngContext rng
+# TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64
 
-type Rng* = ref HmacDrbgContext
-
-proc rand*(rng: Rng, max: Natural): int =
+proc rand*(rng: var SecureRngContext, max: Natural): int =
   if max == 0: return 0
+
   var x: uint64
   while true:
-    let x = rng[].generate(uint64)
+    rng.generate(x)
     if x < randMax - (randMax mod (uint64(max) + 1'u64)): # against modulo bias
       return int(x mod (uint64(max) + 1'u64))
 
-proc genMaskKey*(rng: Rng): array[4, char] =
+proc genMaskKey*(rng: ref SecureRngContext): array[4, char] =
   ## Generates a random key of 4 random chars.
-  proc r(): char = char(rand(rng, 255))
+  proc r(): char = char(rand(rng[], 255))
   return [r(), r(), r(), r()]
 
-proc genWebSecKey*(rng: Rng): seq[byte] =
+proc genWebSecKey*(rng: ref SecureRngContext): seq[byte] =
   var key = newSeq[byte](16)
-  proc r(): byte = byte(rand(rng, 255))
+  proc r(): byte = byte(rand(rng[], 255))
   ## Generates a random key of 16 random chars.
   for i in 0..15:
     key[i] = r()

--- a/websock/websock.nim
+++ b/websock/websock.nim
@@ -117,10 +117,10 @@ proc connect*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: Rng = nil): Future[WSSession] {.async.} =
+  rng: ref SecureRngContext = nil): Future[WSSession] {.async.} =
 
   let
-    rng = if isNil(rng): HmacDrbgContext.new() else: rng
+    rng = if isNil(rng): SecureRngContext.new() else: rng
     key = Base64Pad.encode(genWebSecKey(rng))
     hostname = if hostName.len > 0: hostName else: $host
 
@@ -216,7 +216,7 @@ proc connect*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: Rng = nil): Future[WSSession]
+  rng: ref SecureRngContext = nil): Future[WSSession]
   {.raises: [Defect, WSWrongUriSchemeError].} =
   ## Create a new websockets client
   ## using a Uri
@@ -359,12 +359,12 @@ proc new*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: Rng = nil): WSServer =
+  rng: ref SecureRngContext = nil): WSServer =
 
   return WSServer(
     protocols: @protos,
     masked: false,
-    rng: if isNil(rng): HmacDrbgContext.new() else: rng,
+    rng: if isNil(rng): SecureRngContext.new() else: rng,
     frameSize: frameSize,
     factories: @factories,
     onPing: onPing,


### PR DESCRIPTION
Update `rand` with the implementation from `nim-eth` (no unused `var x`) and change use to have `ref` explicitly for the `Rng` context, similar to how it is done in the other Status libraries. Further align name to `SecureRngContext` (https://github.com/status-im/nim-eth/pull/617)