### PR TITLE
align RNG use with `nim-eth`

### DIFF
--- a/websock/utils.nim
+++ b/websock/utils.nim
@@ -1,5 +1,5 @@
 ## nim-websock
-## Copyright (c) 2021 Status Research & Development GmbH
+## Copyright (c) 2021-2023 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 ##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -7,30 +7,35 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import bearssl/[rand]
-export rand
+{.push raises: [].}
 
-## Random helpers: similar as in stdlib, but with HmacDrbgContext rng
-const randMax = 18_446_744_073_709_551_615'u64
+import bearssl/rand
 
 type Rng* = ref HmacDrbgContext
 
-proc rand*(rng: Rng, max: Natural): int =
+export rand.generate
+
+## Random helpers: similar as in stdlib, but with HmacDrbgContext rng
+# TODO: Move these somewhere else?
+const randMax = 18_446_744_073_709_551_615'u64
+
+proc rand*(rng: var HmacDrbgContext, max: Natural): int =
   if max == 0: return 0
+
   var x: uint64
   while true:
-    let x = rng[].generate(uint64)
+    rng.generate(x)
     if x < randMax - (randMax mod (uint64(max) + 1'u64)): # against modulo bias
       return int(x mod (uint64(max) + 1'u64))
 
 proc genMaskKey*(rng: Rng): array[4, char] =
   ## Generates a random key of 4 random chars.
-  proc r(): char = char(rand(rng, 255))
+  proc r(): char = char(rand(rng[], 255))
   return [r(), r(), r(), r()]
 
 proc genWebSecKey*(rng: Rng): seq[byte] =
   var key = newSeq[byte](16)
-  proc r(): byte = byte(rand(rng, 255))
+  proc r(): byte = byte(rand(rng[], 255))
   ## Generates a random key of 16 random chars.
   for i in 0..15:
     key[i] = r()


### PR DESCRIPTION
Update `rand` with the implementation from `nim-eth`, no unused `var x`.