### PR TITLE
chore: bump version (0.2.1)

### DIFF
--- a/websock.nimble
+++ b/websock.nimble
@@ -8,7 +8,7 @@
 ## those terms.
 
 packageName = "websock"
-version     = "0.2.0"
+version     = "0.2.1"
 author      = "Status Research & Development GmbH"
 description = "WS protocol implementation"
 license     = "MIT"
@@ -18,7 +18,7 @@ requires "nim >= 1.6.0"
 requires "chronos >= 4.0.3 & < 4.1.0"
 requires "httputils >= 0.2.0"
 requires "chronicles >= 0.10.2"
-requires "stew >= 0.1.0"
+requires "stew >= 0.4.2"
 requires "nimcrypto"
 requires "bearssl"
 requires "results"


### PR DESCRIPTION
Recent release of `nim-stew` removed `pkg/results` in favor of `nim-results`. We need a new version of nim-websock that contains that fix.