### PR TITLE
feat(wstransport): add support for concurrent accept

### DIFF
--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -63,7 +63,7 @@ proc createServerNoStart*(
         flags = flags,
       )
     return server
-  except CatchableError as exc:
+  except TransportOsError as exc:
     raise newException(Defect, exc.msg)
 
 proc createServer*(

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -37,6 +37,35 @@ proc waitForClose*(ws: WSSession) {.async.} =
   except CatchableError:
     trace "Closing websocket"
 
+proc createServerNoStart*(
+  address = initTAddress("127.0.0.1:8888"),
+  tlsPrivateKey = TLSPrivateKey.init(SecureKey),
+  tlsCertificate = TLSCertificate.init(SecureCert),
+  flags: set[ServerFlags] = {ServerFlags.TcpNoDelay, ServerFlags.ReuseAddr},
+  tlsFlags: set[TLSFlags] = {},
+  tlsMinVersion = TLSVersion.TLS12,
+  tlsMaxVersion = TLSVersion.TLS12
+): HttpServer {.raises: [].} =
+  try:
+    let server = when defined(secure):
+      HttpServer.create(
+        address = address,
+        tlsPrivateKey = tlsPrivateKey,
+        tlsCertificate = tlsCertificate,
+        flags = flags,
+        tlsFlags = tlsFlags,
+        tlsMinVersion = tlsMinVersion,
+        tlsMaxVersion = tlsMaxVersion,
+      )
+    else:
+      HttpServer.create(
+        address = address,
+        flags = flags,
+      )
+    return server
+  except CatchableError as exc:
+    raise newException(Defect, exc.msg)
+
 proc createServer*(
   address = initTAddress("127.0.0.1:8888"),
   tlsPrivateKey = TLSPrivateKey.init(SecureKey),
@@ -45,23 +74,19 @@ proc createServer*(
   flags: set[ServerFlags] = {ServerFlags.TcpNoDelay, ServerFlags.ReuseAddr},
   tlsFlags: set[TLSFlags] = {},
   tlsMinVersion = TLSVersion.TLS12,
-  tlsMaxVersion = TLSVersion.TLS12): HttpServer
-  {.raises: [].} =
-  try:
-    let server = when defined secure:
-      HttpServer.create(
-        address = address,
-        tlsPrivateKey = tlsPrivateKey,
-        tlsCertificate = tlsCertificate,
-        flags = flags,
-        tlsFlags = tlsFlags,
-        tlsMinVersion = tlsMinVersion,
-        tlsMaxVersion = tlsMaxVersion)
-    else:
-      HttpServer.create(
-        address = address,
-        flags = flags)
+  tlsMaxVersion = TLSVersion.TLS12
+): HttpServer {.raises: [].} =
+  let server = createServerNoStart(
+    address = address,
+    tlsPrivateKey = tlsPrivateKey,
+    tlsCertificate = tlsCertificate,
+    flags = flags,
+    tlsFlags = tlsFlags,
+    tlsMinVersion = tlsMinVersion,
+    tlsMaxVersion = tlsMaxVersion
+  )
 
+  try:
     when defined accepts:
       proc accepts() {.async: (raises: []).} =
         try:

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -1193,6 +1193,16 @@ suite "Partial frames":
     await lowLevelRecv(7, 10, 5)
 
 suite "Test accept":
+  setup:
+    var
+      server = createServerNoStart(address)
+      wsServer = WSServer.new()
+
+  teardown:
+    if server != nil:
+      server.stop()
+      waitFor server.closeWait()
+
   proc runEchoClient(address: TransportAddress, id: string): Future[void] {.async.} =
     let client = await connectClient(address).wait(2.seconds)
     try:
@@ -1209,99 +1219,89 @@ suite "Test accept":
       clientFuts.add(runEchoClient(address, $i))
     await allFutures(clientFuts).wait(5.seconds)
 
-  template withTestServer(body: untyped) =
-    let server {.inject.} = createServerNoStart(address)
-    let wsServer {.inject.} = WSServer.new()
-    try:
-      body
-    finally:
-      server.stop()
-      await server.closeWait()
-
   asyncTest "basic acceptStream test":
-    withTestServer:
-      proc runServer() {.async.} =
-        let clientStream = await server.acceptStream()
-        try:
-          let req = await server.processHttpRequest(clientStream)
-          check req.uri.path == WSPath
-          let wsSession = await wsServer.handleRequest(req)
-          try:
-            let msg = await wsSession.recvMsg()
-            await wsSession.send(msg, Opcode.Text)
-          finally:
-            await wsSession.close()
-        except CatchableError as exc:
-          await clientStream.closeWait()
-          raise exc
-
-      let serverTask = runServer()
-
+    proc runServer() {.async.} =
+      let clientStream = await server.acceptStream()
       try:
-        await runEchoClient(address, "single")
-      finally:
-        if not serverTask.finished:
-          await serverTask.cancelAndWait()
-        else:
-          await serverTask
+        let req = await server.processHttpRequest(clientStream)
+        check req.uri.path == WSPath
+        let wsSession = await wsServer.handleRequest(req)
+        try:
+          let msg = await wsSession.recvMsg()
+          await wsSession.send(msg, Opcode.Text)
+        finally:
+          await wsSession.close()
+      except CatchableError as exc:
+        await clientStream.closeWait()
+        raise exc
+
+    let serverTask = runServer()
+
+    try:
+      await runEchoClient(address, "single")
+    finally:
+      if not serverTask.finished:
+        await serverTask.cancelAndWait()
+      else:
+        await serverTask
 
   asyncTest "concurrent acceptStream test":
-    withTestServer:
-      proc worker(stream: AsyncStream) {.async.} =
-        var wsSession: WSSession
-        try:
-          let req = await server.processHttpRequest(stream)
-          wsSession = await wsServer.handleRequest(req)
-          let msg = await wsSession.recvMsg()
-          await wsSession.send(msg, Opcode.Text)
-        finally:
-          if not isNil(wsSession):
-            await wsSession.close()
-          else:
-            await stream.closeWait()
-
-      proc runServer() {.async.} =
-        while true:
-          try:
-            let clientStream = await server.acceptStream()
-            asyncSpawn worker(clientStream)
-          except CancelledError:
-            break
-
-      let serverTask = runServer()
-
+    proc worker(stream: AsyncStream) {.async.} =
+      var wsSession: WSSession
       try:
-        await runManyClients(address, 100)
+        let req = await server.processHttpRequest(stream)
+        wsSession = await wsServer.handleRequest(req)
+        let msg = await wsSession.recvMsg()
+        await wsSession.send(msg, Opcode.Text)
       finally:
-        await serverTask.cancelAndWait()
-        if serverTask.failed:
-          raise serverTask.error
+        if not isNil(wsSession):
+          await wsSession.close()
+        else:
+          await stream.closeWait()
+
+    proc runServer() {.async.} =
+      while true:
+        try:
+          let clientStream = await server.acceptStream()
+          asyncSpawn worker(clientStream)
+        except CancelledError:
+          # serverTask.cancelAndWait() was called; stop accepting clients.
+          break
+
+    let serverTask = runServer()
+
+    try:
+      await runManyClients(address, 100)
+    finally:
+      await serverTask.cancelAndWait()
+      if serverTask.failed:
+        raise serverTask.error
 
   asyncTest "accept test":
-    withTestServer:
-      proc worker(req: HttpRequest) {.async.} =
-        var wsSession: WSSession
-        try:
-          wsSession = await wsServer.handleRequest(req)
-          let msg = await wsSession.recvMsg()
-          await wsSession.send(msg, Opcode.Text)
-        finally:
-          if not isNil(wsSession):
-            await wsSession.close()
-
-      proc runServer() {.async.} =
-        while true:
-          try:
-            let req = await server.accept()
-            asyncSpawn worker(req)
-          except CancelledError:
-            break
-
-      let serverTask = runServer()
-
+    proc worker(req: HttpRequest) {.async.} =
+      var wsSession: WSSession
       try:
-        await runManyClients(address, 10)
+        wsSession = await wsServer.handleRequest(req)
+        let msg = await wsSession.recvMsg()
+        await wsSession.send(msg, Opcode.Text)
       finally:
-        await serverTask.cancelAndWait()
-        if serverTask.failed:
-          raise serverTask.error
+        if not isNil(wsSession):
+          await wsSession.close()
+
+    proc runServer() {.async.} =
+      while true:
+        try:
+          let req = await server.accept()
+          asyncSpawn worker(req)
+        except CancelledError:
+          # serverTask.cancelAndWait() was called; stop accepting clients.
+          break
+
+    let serverTask = runServer()
+
+    try:
+      await runManyClients(address, 10)
+    finally:
+      await serverTask.cancelAndWait()
+      if serverTask.failed:
+        raise serverTask.error

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -1191,3 +1191,117 @@ suite "Partial frames":
 
   asyncTest "receiver frameSize greater than sender":
     await lowLevelRecv(7, 10, 5)
+
+suite "Test accept":
+  proc runEchoClient(address: TransportAddress, id: string): Future[void] {.async.} =
+    let client = await connectClient(address).wait(2.seconds)
+    try:
+      let payload = "client-" & id
+      await client.send(payload)
+      let res = await client.recvMsg().wait(2.seconds)
+      check string.fromBytes(res) == payload
+    finally:
+      await client.close()
+
+  proc runManyClients(address: TransportAddress, count: int): Future[void] {.async.} =
+    var clientFuts: seq[Future[void]]
+    for i in 0 ..< count:
+      clientFuts.add(runEchoClient(address, $i))
+    await allFutures(clientFuts).wait(5.seconds)
+
+  template withTestServer(body: untyped) =
+    let server {.inject.} = createServerNoStart(address)
+    let wsServer {.inject.} = WSServer.new()
+    try:
+      body
+    finally:
+      server.stop()
+      await server.closeWait()
+
+  asyncTest "basic acceptStream test":
+    withTestServer:
+      proc runServer() {.async.} =
+        let clientStream = await server.acceptStream()
+        try:
+          let req = await server.processHttpRequest(clientStream)
+          check req.uri.path == WSPath
+          let wsSession = await wsServer.handleRequest(req)
+          try:
+            let msg = await wsSession.recvMsg()
+            await wsSession.send(msg, Opcode.Text)
+          finally:
+            await wsSession.close()
+        except CatchableError as exc:
+          await clientStream.closeWait()
+          raise exc
+
+      let serverTask = runServer()
+
+      try:
+        await runEchoClient(address, "single")
+      finally:
+        if not serverTask.finished:
+          await serverTask.cancelAndWait()
+        else:
+          await serverTask
+
+  asyncTest "concurrent acceptStream test":
+    withTestServer:
+      proc worker(stream: AsyncStream) {.async.} =
+        var wsSession: WSSession
+        try:
+          let req = await server.processHttpRequest(stream)
+          wsSession = await wsServer.handleRequest(req)
+          let msg = await wsSession.recvMsg()
+          await wsSession.send(msg, Opcode.Text)
+        finally:
+          if not isNil(wsSession):
+            await wsSession.close()
+          else:
+            await stream.closeWait()
+
+      proc runServer() {.async.} =
+        while true:
+          try:
+            let clientStream = await server.acceptStream()
+            asyncSpawn worker(clientStream)
+          except CancelledError:
+            break
+
+      let serverTask = runServer()
+
+      try:
+        await runManyClients(address, 100)
+      finally:
+        await serverTask.cancelAndWait()
+        if serverTask.failed:
+          raise serverTask.error
+
+  asyncTest "accept test":
+    withTestServer:
+      proc worker(req: HttpRequest) {.async.} =
+        var wsSession: WSSession
+        try:
+          wsSession = await wsServer.handleRequest(req)
+          let msg = await wsSession.recvMsg()
+          await wsSession.send(msg, Opcode.Text)
+        finally:
+          if not isNil(wsSession):
+            await wsSession.close()
+
+      proc runServer() {.async.} =
+        while true:
+          try:
+            let req = await server.accept()
+            asyncSpawn worker(req)
+          except CancelledError:
+            break
+
+      let serverTask = runServer()
+
+      try:
+        await runManyClients(address, 10)
+      finally:
+        await serverTask.cancelAndWait()
+        if serverTask.failed:
+          raise serverTask.error

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -86,6 +86,13 @@ proc readHttpRequest(
     headers: request.toHttpTable(), stream: stream, uri: request.uri().parseUri()
   )
 
+proc processHttpRequest*(
+  server: HttpServer, stream: AsyncStream
+): Future[HttpRequest] {.
+    async: (raises: [CancelledError, AsyncStreamError, HttpError])
+.} =
+  return await readHttpRequest(stream, server.headersTimeout)
+
 proc openAsyncStream(
     server: HttpServer, transp: StreamTransport
 ): Result[AsyncStream, string] =
@@ -129,9 +136,7 @@ proc handleConnCb(
   finally:
     await stream.closeWait()
 
-# TODO async raises not implemented for accept because it breaks libp2p (1.13.0
-#      at the time of writing)
-proc accept*(server: HttpServer): Future[HttpRequest] {.async.} =
+proc acceptStream*(server: HttpServer): Future[AsyncStream] {.async.} =
   if not isNil(server.handler):
     raise newException(
       HttpError, "Callback already registered - cannot mix callback and accepts styles!"
@@ -145,6 +150,13 @@ proc accept*(server: HttpServer): Future[HttpRequest] {.async.} =
       raise (ref HttpError)(msg: error)
 
   trace "Got new request", isTls = server.secure
+  return stream
+
+# TODO async raises not implemented for accept because it breaks libp2p (1.13.0
+#      at the time of writing)
+proc accept*(server: HttpServer): Future[HttpRequest] {.async.} =
+  let stream = await acceptStream(server)
+
   try:
     await stream.readHttpRequest(server.headersTimeout)
   except CancelledError as exc:

--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -91,6 +91,8 @@ proc processHttpRequest*(
 ): Future[HttpRequest] {.
     async: (raises: [CancelledError, AsyncStreamError, HttpError])
 .} =
+  ## Wait for HTTP headers from the stream and return the HttpRequest
+  ##
   return await readHttpRequest(stream, server.headersTimeout)
 
 proc openAsyncStream(
@@ -137,6 +139,9 @@ proc handleConnCb(
     await stream.closeWait()
 
 proc acceptStream*(server: HttpServer): Future[AsyncStream] {.async.} =
+  ## Await a new AsyncStream that connected to the server
+  ##
+
   if not isNil(server.handler):
     raise newException(
       HttpError, "Callback already registered - cannot mix callback and accepts styles!"
@@ -155,6 +160,9 @@ proc acceptStream*(server: HttpServer): Future[AsyncStream] {.async.} =
 # TODO async raises not implemented for accept because it breaks libp2p (1.13.0
 #      at the time of writing)
 proc accept*(server: HttpServer): Future[HttpRequest] {.async.} =
+  ## Await a new, fully-handshaked HttpRequest to the server
+  ##
+
   let stream = await acceptStream(server)
 
   try:


### PR DESCRIPTION
**Overview**

This PR helps address https://github.com/logos-messaging/nwaku/issues/3634 by adding public APIs `acceptStream` and `processHttpRequest` to `HttpServer`. 

Also added a "Test accept" test suite which tests both `accept` and `acceptStream` with `processHttpRequest`.

**Rationale**

Client code that doesn't tolerate the head-of-line blocking of the existing `accept` API can instead (i) call `acceptStream` in a loop, in a dedicated task to create remote-client sockets from the server socket, and (ii) spawn new tasks to call `processHttpRequest` and wait for and process HTTP headers arriving from the client socket (which can take a long time and shouldn't block new remote-client sockets).

Alternatives (tried before):

* [Push everything into nim-websock](https://github.com/status-im/nim-websock/pull/179): The most transparent and localized solution to the bug, but it is arguably the ugliest solution; out of nim-websock's scope; not ideal.
* [Spawn async tasks on the client to call the existing `accept`](https://github.com/vacp2p/nim-libp2p/pull/1919): Even with a [fix to Chronos' inability to handle StreamServer.accept multitasking](https://github.com/status-im/nim-websock/pull/180) we have observed [very weird behavior](https://github.com/vacp2p/nim-libp2p/pull/1919#discussion_r2572290148); in any case, this kind of solution [fights Chronos](https://github.com/status-im/nim-websock/pull/180#issuecomment-3602313319) and is not ideal.
* Spawn an HTTP header parsing task inside `accept`: even if it's still nominally just an `accept` API, client code still has to asyncSpawn, in addition to the asyncSpawn inside `accept`. `HttpRequest` object becomes "hollow" and needs to be populated later; clients need to know that a future inside `HttpRequest` must be awaited before accessing its data fields.
* Callback/handlers: will be deprecated from nim-websock; doesn't solve the problem of the client still having to duplicate HTTP header handling code.