### PR TITLE
feat: make rng agnostic

### DIFF
--- a/tests/extensions/testextflow.nim
+++ b/tests/extensions/testextflow.nim
@@ -116,7 +116,7 @@ suite "Encode frame extensions flow":
       frame.opcode == Opcode.Binary
 
 suite "Decode frame extensions flow":
-  let rng = newWebSocketRng()
+  let rng = bearSslRng(HmacDrbgContext.new())
   var
     address: TransportAddress
     server: StreamServer

--- a/tests/extensions/testextflow.nim
+++ b/tests/extensions/testextflow.nim
@@ -116,11 +116,11 @@ suite "Encode frame extensions flow":
       frame.opcode == Opcode.Binary
 
 suite "Decode frame extensions flow":
-  let rng = HmacDrbgContext.new()
+  let rng = newWebSocketRng()
   var
     address: TransportAddress
     server: StreamServer
-    maskKey = MaskKey.random(rng[])
+    maskKey = MaskKey.random(rng)
     transport: StreamTransport
     reader: AsyncStreamReader
     frame: Frame

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -91,7 +91,7 @@ proc connectClient*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: WebSocketRng = newWebSocketRng()): Future[WSSession] {.async.} =
+  rng: RandomBytesRng = bearSslRng(HmacDrbgContext.new())): Future[WSSession] {.async.} =
   let secure = when defined secure: true else: false
   return await WebSocket.connect(
     host = address,

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -91,7 +91,7 @@ proc connectClient*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng = HmacDrbgContext.new()): Future[WSSession] {.async.} =
+  rng: WebSocketRng = newWebSocketRng()): Future[WSSession] {.async.} =
   let secure = when defined secure: true else: false
   return await WebSocket.connect(
     host = address,

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -19,6 +19,17 @@ import ./helpers
 
 let address = initTAddress("127.0.0.1:8888")
 
+suite "Test RNG":
+  test "custom random-bytes callback":
+    let rng = newWebSocketRng(
+      proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+        for i in 0 ..< dst.len:
+          dst[i] = byte(i + 1)
+        true
+    )
+
+    check MaskKey.random(rng) == [byte 1, 2, 3, 4]
+
 suite "Test handshake":
   setup:
     var
@@ -730,7 +741,7 @@ suite "Test Closing":
 
 suite "Test Payload":
   setup:
-    let rng {.used.} = HmacDrbgContext.new()
+    let rng {.used.} = newWebSocketRng()
     var
       server: HttpServer
 
@@ -834,7 +845,7 @@ suite "Test Payload":
       address = initTAddress("127.0.0.1:8888"),
       frameSize = maxFrameSize)
 
-    let maskKey = MaskKey.random(rng[])
+    let maskKey = MaskKey.random(rng)
     await session.stream.writer.write(
       (await Frame(
         fin: false,
@@ -894,7 +905,7 @@ suite "Test Payload":
         pong = true
     )
 
-    let maskKey = MaskKey.random(rng[])
+    let maskKey = MaskKey.random(rng)
     await session.stream.writer.write(
       (await Frame(
         fin: false,

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -21,20 +21,18 @@ let address = initTAddress("127.0.0.1:8888")
 
 suite "Test RNG":
   test "custom random-bytes callback":
-    let rng = newWebSocketRng(
+    let rng: RandomBytesRng =
       proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
         for i in 0 ..< dst.len:
           dst[i] = byte(i + 1)
         true
-    )
 
     check MaskKey.random(rng) == [byte 1, 2, 3, 4]
 
   test "custom random-bytes callback failure raises WSRngError":
-    let rng = newWebSocketRng(
-      proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+    let rng: RandomBytesRng =
+      proc(_: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
         false
-    )
 
     expect WSRngError:
       discard MaskKey.random(rng)
@@ -750,7 +748,7 @@ suite "Test Closing":
 
 suite "Test Payload":
   setup:
-    let rng {.used.} = newWebSocketRng()
+    let rng {.used.} = bearSslRng(HmacDrbgContext.new())
     var
       server: HttpServer
 

--- a/tests/testwebsockets.nim
+++ b/tests/testwebsockets.nim
@@ -30,6 +30,15 @@ suite "Test RNG":
 
     check MaskKey.random(rng) == [byte 1, 2, 3, 4]
 
+  test "custom random-bytes callback failure raises WSRngError":
+    let rng = newWebSocketRng(
+      proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+        false
+    )
+
+    expect WSRngError:
+      discard MaskKey.random(rng)
+
 suite "Test handshake":
   setup:
     var

--- a/websock/session.nim
+++ b/websock/session.nim
@@ -111,7 +111,7 @@ proc doSend(
 
   let maskKey =
     if ws.masked:
-      MaskKey.random(ws.rng[])
+      MaskKey.random(ws.rng)
     else:
       default(MaskKey)
 

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -235,7 +235,8 @@ proc newWebSocketRng*(randomBytes: RandomBytesProc): WebSocketRng =
   WebSocketRng(randomBytes: randomBytes)
 
 proc generate*(rng: WebSocketRng, dst: var openArray[byte]): bool =
-  doAssert not rng.isNil, "rng cannot be null"
+  if rng.isNil or rng.randomBytes.isNil:
+    return false
   rng.randomBytes(dst)
 
 proc bearSslRng*(rng: ref HmacDrbgContext): WebSocketRng =

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -54,6 +54,11 @@ type
 
   MaskKey* = array[4, byte]
   WebSecKey* = array[16, byte]
+  RandomBytesProc* = proc(dst: var openArray[byte]): bool {.
+    closure, gcsafe, raises: []
+  .}
+  WebSocketRng* = ref object
+    randomBytes: RandomBytesProc
 
   Frame* = ref object
     fin*: bool                 ## Indicates that this is the final fragment in a message.
@@ -88,7 +93,7 @@ type
     masked*: bool             # send masked packets
     binary*: bool             # is payload binary?
     flags*: set[TLSFlags]
-    rng*: ref HmacDrbgContext
+    rng*: WebSocketRng
     frameSize*: int           # max frame buffer size
     onPing*: ControlCb
     onPong*: ControlCb
@@ -167,6 +172,7 @@ type
   WSInvalidUTF8* = object of WebSocketError
   WSExtError* = object of WebSocketError
   WSHookError* = object of WebSocketError
+  WSRngError* = object of WebSocketError
 
 const
   StatusNotUsed* = (StatusCodes(0)..StatusCodes(999))
@@ -219,6 +225,38 @@ method encode*(
 
 method toHttpOptions*(self: Ext): string {.base, gcsafe.} =
   raiseAssert "Not implemented!"
+
+proc newWebSocketRng*(randomBytes: RandomBytesProc): WebSocketRng =
+  ## Create a WebSocket RNG from a random-bytes callback.
+  ##
+  ## The callback must fill the entire destination buffer and return `true` on
+  ## success.
+  doAssert not randomBytes.isNil, "randomBytes cannot be null"
+  WebSocketRng(randomBytes: randomBytes)
+
+proc generate*(rng: WebSocketRng, dst: var openArray[byte]): bool =
+  doAssert not rng.isNil, "rng cannot be null"
+  rng.randomBytes(dst)
+
+proc bearSslRng*(rng: ref HmacDrbgContext): WebSocketRng =
+  ## Wrap an existing BearSSL HMAC-DRBG context.
+  doAssert not rng.isNil, "rng cannot be null"
+  newWebSocketRng(
+    proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+      if dst.len > 0:
+        hmacDrbgGenerate(rng[], addr dst[0], uint dst.len)
+      true
+  )
+
+proc newWebSocketRng*(): WebSocketRng =
+  ## Create the default WebSocket RNG using BearSSL
+  bearSslRng(HmacDrbgContext.new())
+
+proc random*(
+    T: typedesc[MaskKey | WebSecKey], rng: WebSocketRng
+): T {.raises: [WebSocketError].} =
+  if not rng.generate(result):
+    raise newException(WSRngError, "Failed to generate WebSocket random bytes")
 
 func random*(T: typedesc[MaskKey | WebSecKey], rng: var HmacDrbgContext): T =
   rng.generate(result)

--- a/websock/types.nim
+++ b/websock/types.nim
@@ -54,11 +54,9 @@ type
 
   MaskKey* = array[4, byte]
   WebSecKey* = array[16, byte]
-  RandomBytesProc* = proc(dst: var openArray[byte]): bool {.
+  RandomBytesRng* = proc(dst: var openArray[byte]): bool {.
     closure, gcsafe, raises: []
   .}
-  WebSocketRng* = ref object
-    randomBytes: RandomBytesProc
 
   Frame* = ref object
     fin*: bool                 ## Indicates that this is the final fragment in a message.
@@ -93,7 +91,7 @@ type
     masked*: bool             # send masked packets
     binary*: bool             # is payload binary?
     flags*: set[TLSFlags]
-    rng*: WebSocketRng
+    rng*: RandomBytesRng
     frameSize*: int           # max frame buffer size
     onPing*: ControlCb
     onPong*: ControlCb
@@ -226,35 +224,21 @@ method encode*(
 method toHttpOptions*(self: Ext): string {.base, gcsafe.} =
   raiseAssert "Not implemented!"
 
-proc newWebSocketRng*(randomBytes: RandomBytesProc): WebSocketRng =
-  ## Create a WebSocket RNG from a random-bytes callback.
-  ##
-  ## The callback must fill the entire destination buffer and return `true` on
-  ## success.
-  doAssert not randomBytes.isNil, "randomBytes cannot be null"
-  WebSocketRng(randomBytes: randomBytes)
-
-proc generate*(rng: WebSocketRng, dst: var openArray[byte]): bool =
-  if rng.isNil or rng.randomBytes.isNil:
+proc generate*(rng: RandomBytesRng, dst: var openArray[byte]): bool =
+  if rng.isNil:
     return false
-  rng.randomBytes(dst)
+  rng(dst)
 
-proc bearSslRng*(rng: ref HmacDrbgContext): WebSocketRng =
+proc bearSslRng*(rng: ref HmacDrbgContext): RandomBytesRng =
   ## Wrap an existing BearSSL HMAC-DRBG context.
   doAssert not rng.isNil, "rng cannot be null"
-  newWebSocketRng(
-    proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
-      if dst.len > 0:
-        hmacDrbgGenerate(rng[], addr dst[0], uint dst.len)
-      true
-  )
-
-proc newWebSocketRng*(): WebSocketRng =
-  ## Create the default WebSocket RNG using BearSSL
-  bearSslRng(HmacDrbgContext.new())
+  proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+    if dst.len > 0:
+      hmacDrbgGenerate(rng[], addr dst[0], uint dst.len)
+    true
 
 proc random*(
-    T: typedesc[MaskKey | WebSecKey], rng: WebSocketRng
+    T: typedesc[MaskKey | WebSecKey], rng: RandomBytesRng
 ): T {.raises: [WebSocketError].} =
   if not rng.generate(result):
     raise newException(WSRngError, "Failed to generate WebSocket random bytes")

--- a/websock/websock.nim
+++ b/websock/websock.nim
@@ -103,7 +103,7 @@ proc connect*(
     onPing: ControlCb = nil,
     onPong: ControlCb = nil,
     onClose: CloseCb = nil,
-    rng = HmacDrbgContext.new(),
+    rng: WebSocketRng = newWebSocketRng(),
 ): Future[WSSession] {.
     async: (
       raises:
@@ -111,7 +111,7 @@ proc connect*(
     )
 .} =
   let
-    key = Base64Pad.encode(WebSecKey.random(rng[]))
+    key = Base64Pad.encode(WebSecKey.random(rng))
     hostname = if hostName.len > 0: hostName else: $host
 
   var
@@ -197,6 +197,46 @@ proc connect*(
 
 proc connect*(
     _: type WebSocket,
+    host: string | TransportAddress,
+    path: string,
+    hostName: string = "",
+      # override used when the hostname has been externally resolved
+    protocols: seq[string] = @[],
+    factories: seq[ExtFactory] = @[],
+    hooks: seq[Hook] = @[],
+    secure = false,
+    flags: set[TLSFlags] = {},
+    version = WSDefaultVersion,
+    frameSize = WSDefaultFrameSize,
+    onPing: ControlCb = nil,
+    onPong: ControlCb = nil,
+    onClose: CloseCb = nil,
+    rng: ref HmacDrbgContext,
+): Future[WSSession] {.
+    async: (
+      raises:
+        [CancelledError, AsyncStreamError, HttpError, TransportError, WebSocketError]
+    )
+.} =
+  await WebSocket.connect(
+    host = host,
+    path = path,
+    hostName = hostName,
+    protocols = protocols,
+    factories = factories,
+    hooks = hooks,
+    secure = secure,
+    flags = flags,
+    version = version,
+    frameSize = frameSize,
+    onPing = onPing,
+    onPong = onPong,
+    onClose = onClose,
+    rng = bearSslRng(rng),
+  )
+
+proc connect*(
+    _: type WebSocket,
     uri: Uri,
     protocols: seq[string] = @[],
     factories: seq[ExtFactory] = @[],
@@ -207,7 +247,7 @@ proc connect*(
     onPing: ControlCb = nil,
     onPong: ControlCb = nil,
     onClose: CloseCb = nil,
-    rng = HmacDrbgContext.new(),
+    rng: WebSocketRng = newWebSocketRng(),
 ): Future[WSSession] {.
     async: (
       raises:
@@ -244,6 +284,39 @@ proc connect*(
     onPong = onPong,
     onClose = onClose,
     rng = rng,
+  )
+
+proc connect*(
+    _: type WebSocket,
+    uri: Uri,
+    protocols: seq[string] = @[],
+    factories: seq[ExtFactory] = @[],
+    hooks: seq[Hook] = @[],
+    flags: set[TLSFlags] = {},
+    version = WSDefaultVersion,
+    frameSize = WSDefaultFrameSize,
+    onPing: ControlCb = nil,
+    onPong: ControlCb = nil,
+    onClose: CloseCb = nil,
+    rng: ref HmacDrbgContext,
+): Future[WSSession] {.
+    async: (
+      raises:
+        [CancelledError, AsyncStreamError, HttpError, TransportError, WebSocketError]
+    )
+.} =
+  await WebSocket.connect(
+    uri = uri,
+    protocols = protocols,
+    factories = factories,
+    hooks = hooks,
+    flags = flags,
+    version = version,
+    frameSize = frameSize,
+    onPing = onPing,
+    onPong = onPong,
+    onClose = onClose,
+    rng = bearSslRng(rng),
   )
 
 proc handleRequest*(
@@ -350,7 +423,7 @@ proc new*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng = HmacDrbgContext.new()): WSServer =
+  rng: WebSocketRng = newWebSocketRng()): WSServer =
 
   return WSServer(
     protocols: @protos,
@@ -361,3 +434,22 @@ proc new*(
     onPing: onPing,
     onPong: onPong,
     onClose: onClose)
+
+proc new*(
+  _: typedesc[WSServer],
+  protos: openArray[string] = [""],
+  factories: openArray[ExtFactory] = [],
+  frameSize = WSDefaultFrameSize,
+  onPing: ControlCb = nil,
+  onPong: ControlCb = nil,
+  onClose: CloseCb = nil,
+  rng: ref HmacDrbgContext): WSServer =
+
+  WSServer.new(
+    protos = protos,
+    factories = factories,
+    frameSize = frameSize,
+    onPing = onPing,
+    onPong = onPong,
+    onClose = onClose,
+    rng = bearSslRng(rng))

--- a/websock/websock.nim
+++ b/websock/websock.nim
@@ -103,7 +103,7 @@ proc connect*(
     onPing: ControlCb = nil,
     onPong: ControlCb = nil,
     onClose: CloseCb = nil,
-    rng: WebSocketRng = newWebSocketRng(),
+    rng: RandomBytesRng = bearSslRng(HmacDrbgContext.new()),
 ): Future[WSSession] {.
     async: (
       raises:
@@ -213,6 +213,7 @@ proc connect*(
     onClose: CloseCb = nil,
     rng: ref HmacDrbgContext,
 ): Future[WSSession] {.
+    deprecated: "use the RandomBytesRng overload",
     async: (
       raises:
         [CancelledError, AsyncStreamError, HttpError, TransportError, WebSocketError]
@@ -247,7 +248,7 @@ proc connect*(
     onPing: ControlCb = nil,
     onPong: ControlCb = nil,
     onClose: CloseCb = nil,
-    rng: WebSocketRng = newWebSocketRng(),
+    rng: RandomBytesRng = bearSslRng(HmacDrbgContext.new()),
 ): Future[WSSession] {.
     async: (
       raises:
@@ -423,7 +424,7 @@ proc new*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: WebSocketRng = newWebSocketRng()): WSServer =
+  rng: RandomBytesRng = bearSslRng(HmacDrbgContext.new())): WSServer =
 
   return WSServer(
     protocols: @protos,
@@ -443,7 +444,8 @@ proc new*(
   onPing: ControlCb = nil,
   onPong: ControlCb = nil,
   onClose: CloseCb = nil,
-  rng: ref HmacDrbgContext): WSServer =
+  rng: ref HmacDrbgContext): WSServer {.
+    deprecated: "use the RandomBytesRng overload".} =
 
   WSServer.new(
     protos = protos,


### PR DESCRIPTION
## Summary

Introduce a backend-neutral RNG abstraction for WebSocket randomness.

This PR adds `WebSocketRng`, backed by a random-bytes callback. BearSSL remains the default RNG and explicit BearSSL compatibility overloads are kept for `HmacDrbgContext` callers.

## Motivation

`nim-websock` currently exposes BearSSL RNG types in its public API. That makes downstream projects depend on BearSSL. This change lets callers provide randomness from any backend while preserving BearSSL compatibility
