### PR TITLE
fix(http/server): always declare remoteAddr

### DIFF
--- a/websock/http/server.nim
+++ b/websock/http/server.nim
@@ -47,9 +47,8 @@ proc readHttpRequest*(
 .} =
   ## Process transport data to the HTTP server
   ##
-  when chronicles.enabledLogLevel == LogLevel.TRACE:
-    let remoteAddr =
-      stream.reader.tsource.remoteAddress2().valueOr(default(TransportAddress))
+  let remoteAddr =
+    stream.reader.tsource.remoteAddress2().valueOr(default(TransportAddress))
 
   trace "Received connection", remoteAddr
 


### PR DESCRIPTION
**Problem**

In readHttpRequest, `remoteAddr` is declared under a `when chronicles.enabledLogLevel == LogLevel.TRACE` guard, but used in 6 trace statements outside it. Any build that compiles log statements while the level isn't TRACE fails:

```nim
websock/http/server.nim(54, 32) Error: undeclared identifier: 'remoteAddr'
```

This happens when logs are compiled at all levels and filtered at runtime instead of at compile time, e.g. `-d:chronicles_log_level=NONE` with `[dynamic]` sinks, or `-d:chronicles_runtime_filtering=on`.

**Fix** 

Declare `remoteAddr` unconditionally